### PR TITLE
Resolve absence and mismatch in image layout handling

### DIFF
--- a/napari_spotiflow/_predict_widget.py
+++ b/napari_spotiflow/_predict_widget.py
@@ -40,7 +40,7 @@ from .utils import (
 LOGO = Path(__file__).parent / "resources" / "spotiflow_transp_small.png"
 
 BASE_IMAGE_AXES_CHOICES = ["YX", "YXC", "CYX", "TYX", "TYXC", "TCYX"]
-BASE_IMAGE_AXES_CHOICES_3D = [
+BASE_IMAGE_AXES_CHOICES_3D = ["CZYX", "TCZYX"]+[
     f"Z{axes}" if "T" not in axes else f"TZ{axes[1:]}"
     for axes in BASE_IMAGE_AXES_CHOICES
 ]

--- a/napari_spotiflow/utils.py
+++ b/napari_spotiflow/utils.py
@@ -1,58 +1,77 @@
-import numpy as np
 from typing import Literal
+
+import numpy as np
 from napari.utils import progress as napari_progress
 
-_point_layer2d_default_kwargs = dict(size=8,
-                                     symbol='ring',
-                                     opacity=1,
-                                     face_color=[1.,.5,.2],
-                                     border_color=[1.,.5,.2])
+# fmt: off
+SUPPORTED_AXES_LAYOUTS = Literal[
+      "YX",   "YXC",   "CYX",
+     "TYX",  "TYXC",  "TCYX",
+     "ZYX",  "ZYXC",  "ZCYX",  "CZYX",
+    "TZYX", "TZYXC", "TZCYX", "TCZYX",
+]  # No "ZT*", etc.
+# fmt: on
 
-_point_layer3d_default_kwargs = dict(size=8,
-                                     symbol='ring',
-                                     opacity=1,
-                                     face_color=[1.,.5,.2],
-                                     border_color=[1.,.5,.2],
-                                     out_of_slice_display=True)
+_point_layer2d_default_kwargs = dict(
+    size=8,
+    symbol="ring",
+    opacity=1,
+    face_color=[1.0, 0.5, 0.2],
+    border_color=[1.0, 0.5, 0.2],
+)
 
-def _validate_axes(img: np.ndarray, axes: Literal["YX", "YXC", "CYX", "TYX", "TYXC", "TCYX", "ZYX", "ZYXC", "CZYX", "ZTYX", "ZTYXC", "ZTCYX"]) -> None:
-    assert img.ndim == len(axes), f"Image has {img.ndim} dimensions, but axes has {len(axes)} dimensions"
-    return
+_point_layer3d_default_kwargs = dict(
+    size=8,
+    symbol="ring",
+    opacity=1,
+    face_color=[1.0, 0.5, 0.2],
+    border_color=[1.0, 0.5, 0.2],
+    out_of_slice_display=True,
+)
 
-def _prepare_input(img: np.ndarray, axes: Literal["YX", "YXC", "CYX", "TYX", "TYXC", "TCYX", "ZYX", "ZYXC", "CZYX", "ZTYX", "TZYXC", "TCZYX"]) -> np.ndarray:
-    """Reshape input for Spotiflow's API compatibility. If `axes` contains "Z", then assumes `img` is a volumetric (3D) image.
+
+def _validate_axes(img: np.ndarray, axes: SUPPORTED_AXES_LAYOUTS) -> None:
+    """Validate that the number of dimensions in the image matches the given axes string."""
+    if img.ndim != len(axes):
+        raise ValueError(
+            f"Image has {img.ndim} dimensions, but axes has {len(axes)} dimensions"
+        )
+
+
+def _prepare_input(img: np.ndarray, axes: SUPPORTED_AXES_LAYOUTS) -> np.ndarray:
+    """Reshape input for Spotiflow's API compatibility based on axes notation.
 
     Args:
-        img (np.ndarray): input image to be reformatted
-        axes (Literal["YX", "YXC", "CYX", "TYX", "TYXC", "TCYX", "ZYX", "ZYXC", "ZCYX", "ZTYX", "ZTYXC", "ZTCYX"]): given axes
-
-    Raises:
-        ValueError: thrown if axis is not valid
+        img (np.ndarray): Input image array.
+        axes (str): Axes representation of the image.
 
     Returns:
-        np.ndarray: reshaped NumPy array compatible with Spotiflow's `predict` API
+        np.ndarray: Image reshaped into Spotiflow-compatible format.
     """
     _validate_axes(img, axes)
-    if axes == "YX" or axes == "ZYX":
+
+    if axes in {"YX", "ZYX", "TYX", "TZYX"}:
         return img[..., None]
-    elif axes == "YXC" or axes == "ZYXC":
+    elif axes in {"YXC", "ZYXC", "TYXC", "TZYXC"}:
         return img
     elif axes == "CYX":
-        return img.transpose(1,2,0)
+        return img.transpose(1, 2, 0)
     elif axes == "CZYX":
-        return img.transpose(1,2,3,0)
-    elif axes == "TYX" or axes == "TZYX":
-        return img[..., None]
-    elif axes == "TYXC" or axes == "TZYXC":
-        return img
+        return img.transpose(1, 2, 3, 0)
+    elif axes == "ZCYX":
+        return img.transpose(0, 2, 3, 1)
     elif axes == "TCYX":
-        return img.transpose(0,2,3,1)
+        return img.transpose(0, 2, 3, 1)
+    elif axes == "TZCYX":
+        return img.transpose(0, 1, 3, 4, 2)
     elif axes == "TCZYX":
-        return img.transpose(0,2,3,4,0)
+        return img.transpose(0, 2, 3, 4, 1)
     else:
         raise ValueError(f"Invalid axes: {axes}")
+
 
 def _patched_progbar(desc):
     def _progbar(*args, **kwargs):
         return napari_progress(*args, desc=desc, **kwargs)
+
     return _progbar


### PR DESCRIPTION
The `axes` argument in `_validate_axes`/`_prepare_input` functions and docstrings had inconsistencies. The default Napari `ZCYX` layout was provided as an option in the GUI but missing in code, and the `TCZYX` layout in code had an incorrect transpose.

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Hi @AlbertDominguez thanks for your plugin! This PR allows users to predict multi-channel 3D volumes with 3D networks. I

1. Added a missing transposition for default Napari layout `ZCYX` (this is how a multi-channel 3D TIFF is loaded by Spotiflow plugin and a default option shown in its GUI); #5 
2. Corrected the transpose of layout `TCZYX`;
3. Made the supported axes layouts clear and consistent.

## Related issues (if applicable)

- Related Issue https://github.com/weigertlab/spotiflow/issues/33
- Closes #5 

PS: I saw Black is used from this repo's precommit configs so I did the same for this commit though it doesn't seem to have been used.